### PR TITLE
Changes to request timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = Client;
 function Client(addr, opts) {
   opts = opts || {};
   this.addr = addr;
-  this.timeout = opts.timeout || 30000;
+  this.timeout = opts.timeout || 10000;
 }
 
 /**
@@ -37,7 +37,9 @@ function Client(addr, opts) {
  * @return {Promise}
  */
 
-Client.prototype.call = function(method, params) {
+Client.prototype.call = function(method, params, options) {
+  if (!options) options = {};
+
   const id = uid(16);
   const body = {
     method: method,
@@ -50,7 +52,7 @@ Client.prototype.call = function(method, params) {
     json: true,
     method: 'POST',
     uri: this.addr,
-    timeout: this.timeout,
+    timeout: options.timeout || this.timeout,
     body: body
   };
 

--- a/test/index.js
+++ b/test/index.js
@@ -67,5 +67,17 @@ describe('jsonrpc2', function() {
       assert(err);
       assert.equal(err.code, 'ETIMEDOUT');
     });
+
+    it('should support per-request timeout', function*() {
+      const c = new Client(client.addr);
+      let err = null;
+      try {
+        yield c.call('sleep', [{ time: 100 }], { timeout: 50 });
+      } catch (e) {
+        err = e;
+      }
+      assert(err);
+      assert.equal(err.code, 'ETIMEDOUT');
+    });
   });
 });


### PR DESCRIPTION
This makes 2 changes to the internal "timeout" for this module:

1. client: lower default timeout to 3s (from 30s)
2. call: add `options.timeout` (to override the client's default timeout set previously)

The current default timeout of 30s is just absurdly long, so I lowered it to 3s. I figure most requests we want even faster than that, but you should opt-in for longer timeouts in my opinion. I'm open to changing this value back, or using another default value.

This is mainly prompted by random failures in the app during testing. Most of our requests are reads that are wrapped in `try/catch` so we can be more tolerant of them failing. Currently, slowness in Stripe causes tests to fail inexplicably, and most of those failures are unrelated to the Stripe endpoint that was being slow.

I'd also like to start setting more context-appropriate timeouts on our various JSON-RPCv2 wrappers, in fact maybe we could be more aggressive about timing out quickly. (it's worth noting that even if something times out, the request will still finish async, so we won't lose any data)

/cc @stevenmiller888 @stephenmathieson 