### PR TITLE
Allow for async processing

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function Client(addr, opts) {
 Client.prototype.call = function(method, params, options) {
   if (!options) options = {};
 
-  const id = uid(16);
+  const id = options.async ? null : uid(16);
   const body = {
     method: method,
     params: params,

--- a/test/index.js
+++ b/test/index.js
@@ -80,4 +80,12 @@ describe('jsonrpc2', function() {
       assert.equal(err.code, 'ETIMEDOUT');
     });
   });
+
+  describe('async requests', function() {
+    it('should send a null id', function*() {
+      const c = new Client(client.addr);
+      const res = yield c.call('echo', [], { async: true });
+      assert.strictEqual(res.id, null);
+    });
+  });
 });


### PR DESCRIPTION
This builds on #5 and adds `options.async` to requests, which internally uses `null` for the request `id`. This just means that the JSON-RPC server should not block the client while it waits for an answer, it will simply complete the request asynchronously.

This could be useful where we don't necessarily care about waiting for the response, such as during sign up. Subsequent gets will just silently fail until the background work is done. This is just an idea, we'll have to see if it works in practice.

/cc @stephenmathieson @stevenmiller888 