### PR TITLE
call: support passing non-arrays for params

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Available `opts`:
 
 ### Client#call(method, params, [options])
 
-Calls the given `method` with the given `params`. (make sure you set `params` as an array
-of arguments)
+Calls the given `method` with the given `params`. (if not an array, it will be converted)
 
 Available `options`:
  - `timeout` override the default client timeout

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ Client.prototype.call = function(method, params, options) {
   const id = options.async ? null : uid(16);
   const body = {
     method: method,
-    params: params,
+    params: Array.isArray(params) ? params : [ params ],
     id: id,
     jsonrpc: '2.0' // http://www.jsonrpc.org/specification
   };

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,11 @@ describe('jsonrpc2', function() {
     assert.deepEqual(res.params, [ true ]);
   });
 
+  it('should allow a non-array for a single param', function*() {
+    const res = yield client.call('echo', true);
+    assert.deepEqual(res.params, [ true ]);
+  });
+
   describe('when the request fails', function() {
     it('should throw', function*() {
       let err = null;


### PR DESCRIPTION
Just a bit of sugar, this allows passing a non-array for `params`, which will be converted into an array. No more extra `[ ... ]` wrappers, since we always just use 1 param.

/cc @stevenmiller888 @stephenmathieson 