### PR TITLE
index: add request logger support

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -95,4 +95,20 @@ describe('jsonrpc2', function () {
       assert.strictEqual(res.id, null)
     })
   })
+
+  describe('when given `opts.logger`', function () {
+    it('should log the requests', function * () {
+      let logged = false
+      const logger = function ({ method, duration }) {
+        assert.equal(method, 'sleep')
+        assert(duration > 100)
+        assert(duration < 200)
+        logged = true
+      }
+
+      const c = new Client(client.addr, { logger })
+      yield c.call('sleep', { time: 100 })
+      assert(logged)
+    })
+  })
 })


### PR DESCRIPTION
when given an `opts.logger` function, we'll invoke it after each request will
all available metadata (method, request duration, request params, etc.).

i'll be using this to add some profiling/metrics around slow rpc calls in production
so it's much easier to identify pain-points.

an example implementation could look like:

```js
const client = new Client('http://some-service.localhost/rpc', { logger: rpcLogger })
yield client.call('Some.Method', { foo: 'bar' })

// ...
const logger = bunyan({ ... })
function rpcLogger ({ method, params, duration }) {
  // rpc call took more than 500ms
  if (duration > 500) {
    logger.warn('slow rpc call', { method, params, duration })
  }
}
```

/cc @dominicbarnes you seem to be maintaining this lib ;)