### PR TITLE
Modify to work on node 4

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,6 @@
-
 machine:
   node:
-    version: 6
+    version: 4
 
 dependencies:
   cache_directories:

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ Client.prototype.call = function (method, params, options) {
  */
 
 Client.prototype.request = function (opts, fn) {
-  const { id } = opts
+  const id = opts.id
   debug('request %j', opts.body)
   request.post(opts, function (err, res, body) {
     body = body || {}

--- a/test/app.js
+++ b/test/app.js
@@ -8,7 +8,7 @@
  */
 
 const koa = require('koa')
-const { post } = require('koa-route')
+const post = require('koa-route').post
 const json = require('koa-json-body')
 
 /**
@@ -22,8 +22,9 @@ const api = {
   error: function * () {
     throw new Error('boom!')
   },
-  sleep: function ({ params }) {
-    const { time } = params[0]
+  sleep: function (body) {
+    const params = body.params
+    const time = params[0].time
     return function (done) {
       setTimeout(done, time)
     }
@@ -45,7 +46,8 @@ app.use(post('/rpc', rpc))
 
 function * rpc () {
   const body = this.request.body
-  const { id, method } = body
+  const id = body.id
+  const method = body.method
 
   const res = {
     jsonrpc: '2.0',

--- a/test/index.js
+++ b/test/index.js
@@ -99,7 +99,9 @@ describe('jsonrpc2', function () {
   describe('when given `opts.logger`', function () {
     it('should log the requests', function * () {
       let logged = false
-      const logger = function ({ method, duration }) {
+      const logger = function (body) {
+        const method = body.method
+        const duration = body.duration
         assert.equal(method, 'sleep')
         assert(duration > 100)
         assert(duration < 200)


### PR DESCRIPTION
Basically just remove all destructuring assignments/params. A lot of
services still run on Node 4, our internal policy on libs is to make
them work on whatever LTS is