### PR TITLE
Add middleware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,34 @@ Available `options`:
  - `timeout` override the default client timeout
  - `async` use this when you don't need the answer back from the server (ie: it will set `id: null`)
  - `forceArray` use this when you want the request params to be converted to an array (default: true)
+ 
+### Client#use(middleware)
+
+Adds a custom middleware to the stack, allowing to customize input and even result, intercept calls or abort them completely.
+
+Middleware is a function that accepts these arguments:
+
+- `context` object which contains all data related to the current call
+  - `method` method to call
+  - `params` params (input) of the call
+  - `options` options passed to `call()`
+  - `result` response from the server (equals to `null` before server answers)
+- `next` call next middleware in the stack, returns a promise
+
+Here's an example middleware to measure call time:
+
+```js
+client.use(async (context, next) => {
+  const startTime = new Date()
+  await next()
+  const duration = new Date() - startTime
+  
+  console.log(`${context.method} spent ${duration}ms`)
+})
+
+await client.call('echo', 'Hello World')
+//=> "echo spent 2ms"
+```
 
 ## Developers
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const parseUrl = require('url').parse
 const net = require('net')
 const request = require('request')
+const compose = require('koa-compose')
 const debug = require('debug')('jsonrpc2')
 const split = require('split2')
 const once = require('once')
@@ -28,6 +29,12 @@ class Client {
     this.timeout = options.timeout || 10000
     this.logger = options.logger || noop
     this.userAgent = options.userAgent || null
+    this.middleware = []
+
+    this.logMiddleware = this.logMiddleware.bind(this)
+    this.callMiddleware = this.callMiddleware.bind(this)
+
+    this.rebuildMiddleware()
   }
 
   makeHTTPRequest (body, options, fn) {
@@ -84,10 +91,37 @@ class Client {
     socket.write(JSON.stringify(body))
   }
 
+  use (middleware) {
+    this.middleware.push(middleware)
+    this.rebuildMiddleware()
+  }
+
+  rebuildMiddleware () {
+    this.exec = compose([].concat(
+      this.logMiddleware,
+      this.middleware,
+      this.callMiddleware
+    ))
+  }
+
   call (method, params, options) {
-    options = Object.assign({
+    const context = {
+      method,
+      params,
+      options,
+      result: null
+    }
+
+    return this.exec(context).then(() => context.result)
+  }
+
+  callMiddleware (context) {
+    const options = Object.assign({
       forceArray: true
-    }, options)
+    }, context.options)
+
+    const params = context.params
+    const method = context.method
 
     const forceArray = options.forceArray && !Array.isArray(params)
 
@@ -99,31 +133,41 @@ class Client {
     }
 
     return new Promise((resolve, reject) => {
-      const startTime = new Date()
-
       this.request(body, options, (err, result) => {
-        const duration = new Date() - startTime
-        this.log(method, params, duration, result, err)
-
         if (err) {
           reject(err)
           return
         }
 
-        resolve(result)
+        context.result = result
+        resolve()
       })
     })
   }
 
-  log (method, params, duration, result, error) {
-    this.logger({
-      method,
-      params,
-      duration,
-      result,
-      error,
-      addr: this.address
-    })
+  logMiddleware (context, next) {
+    const startTime = new Date()
+
+    const log = err => {
+      const duration = new Date() - startTime
+
+      this.logger({
+        method: context.method,
+        params: context.params,
+        duration,
+        result: context.result,
+        error: err || null,
+        addr: this.address
+      })
+
+      if (err) {
+        return Promise.reject(err)
+      }
+    }
+
+    return next()
+      .then(log)
+      .catch(log)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "bluebird": "~2.9.25",
     "debug": "^2.2.0",
+    "koa-compose": "^4.0.0",
     "once": "^1.4.0",
     "request": "^2.57.0",
     "split2": "^2.1.0",

--- a/test/http.js
+++ b/test/http.js
@@ -1,6 +1,4 @@
-import {parse as parseUrl} from 'url'
 import http from 'http'
-import {spy} from 'sinon'
 import test from 'ava'
 import Client from '..'
 import app from './_app'
@@ -85,23 +83,4 @@ test('send empty id on async request', async t => {
   const client = new Client(address)
   const res = await client.call('echo', [], { async: true })
   t.is(res.id, null)
-})
-
-test('log', async t => {
-  const logger = spy(options => {
-    t.is(options.method, 'echo')
-    t.deepEqual(options.params, { hello: 'world' })
-    t.true(options.duration > 0)
-    t.deepEqual(options.result.params, [{ hello: 'world' }])
-    t.is(options.result.method, 'echo')
-    t.is(options.result.jsonrpc, '2.0')
-    t.true(options.result.id.length > 0)
-    t.is(options.error, null)
-    t.deepEqual(options.addr, parseUrl(address))
-  })
-
-  const client = new Client(address, { logger })
-  await client.call('echo', { hello: 'world' })
-
-  t.true(logger.calledOnce)
 })

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -1,0 +1,196 @@
+import {spy} from 'sinon'
+import test from 'ava'
+import Client from '..'
+
+const createClient = options => new Client(`tcp://localhost`, options)
+
+test('throw when middleware isn\'t a function', t => {
+  const client = createClient()
+
+  t.throws(() => client.use(), 'Expected middleware to be a function, got undefined')
+})
+
+test('pass context to the middleware and return result', async t => {
+  const client = createClient()
+  client.request = spy((body, options, callback) => callback(null, 'world'))
+
+  const middleware = spy((context, next) => next())
+  client.use(middleware)
+
+  const res = await client.call('test', 'hello', { async: true })
+
+  t.is(res, 'world')
+  t.true(client.request.calledOnce)
+  t.deepEqual(client.request.firstCall.args[0], {
+    params: ['hello'],
+    jsonrpc: '2.0',
+    id: null,
+    method: 'test'
+  })
+
+  t.deepEqual(client.request.firstCall.args[1], {
+    async: true,
+    forceArray: true
+  })
+
+  t.true(middleware.calledOnce)
+  t.deepEqual(middleware.firstCall.args[0], {
+    method: 'test',
+    params: ['hello'],
+    options: {
+      async: true,
+      forceArray: true
+    },
+    result: 'world'
+  })
+})
+
+test('modify context', async t => {
+  const client = createClient()
+  client.request = spy((body, options, callback) => callback(null, body.params[0].message))
+
+  const middleware = (context, next) => {
+    context.params[0].message = 'bye'
+    return next()
+  }
+
+  client.use(middleware)
+
+  const res = await client.call('echo', { message: 'hello' }, { async: true })
+
+  t.is(res, 'bye')
+  t.true(client.request.calledOnce)
+  t.deepEqual(client.request.firstCall.args[0], {
+    params: [{ message: 'bye' }],
+    jsonrpc: '2.0',
+    id: null,
+    method: 'echo'
+  })
+})
+
+test('modify response', async t => {
+  const client = createClient()
+  client.request = spy((body, options, callback) => callback(null, body.params[0]))
+
+  const middleware = async (context, next) => {
+    await next()
+    context.result = 'bye'
+  }
+
+  client.use(middleware)
+
+  const res = await client.call('echo', 'hello')
+
+  t.is(res, 'bye')
+})
+
+test('abort call', async t => {
+  const client = createClient()
+  client.request = spy()
+
+  const middleware = async context => {
+    context.result = 'bye'
+  }
+
+  client.use(middleware)
+
+  const res = await client.call('echo', 'hello')
+
+  t.is(res, 'bye')
+  t.false(client.request.called)
+})
+
+test('error from call', async t => {
+  const client = createClient()
+  client.request = spy((body, options, callback) => callback(new Error('Oops')))
+
+  const middleware = async (context, next) => {
+    try {
+      await next()
+    } catch (err) {
+      err.intercepted = true
+      throw err
+    }
+  }
+
+  client.use(middleware)
+
+  const err = await t.throws(client.call('echo', 'hello'))
+
+  t.is(err.message, 'Oops')
+  t.true(err.intercepted)
+})
+
+test('error from middleware', async t => {
+  const client = createClient()
+  client.request = spy()
+
+  const goodMiddleware = async (context, next) => {
+    try {
+      await next()
+    } catch (err) {
+      err.intercepted = true
+      throw err
+    }
+  }
+
+  const badMiddleware = async () => {
+    throw new Error('Oops')
+  }
+
+  client.use(goodMiddleware)
+  client.use(badMiddleware)
+
+  const err = await t.throws(client.call('echo', 'hello'))
+
+  t.is(err.message, 'Oops')
+  t.true(err.intercepted)
+  t.false(client.request.called)
+})
+
+test('log on success', async t => {
+  const client = createClient()
+  client.request = (body, options, callback) => callback(null, 'success')
+  client.logger = spy()
+
+  await client.call('test', { key: 'value' })
+
+  t.true(client.logger.calledOnce)
+
+  const data = client.logger.firstCall.args[0]
+
+  t.is(typeof data.duration, 'number')
+  t.true(data.duration > 0)
+  t.deepEqual(data, {
+    method: 'test',
+    params: [{ key: 'value' }],
+    duration: data.duration,
+    result: 'success',
+    error: null,
+    addr: client.address
+  })
+})
+
+test('log on error', async t => {
+  const client = createClient()
+  client.request = (body, options, callback) => callback(new Error('Oops'), null)
+  client.logger = spy()
+
+  const err = await t.throws(client.call('test', { key: 'value' }))
+
+  t.is(err.message, 'Oops')
+  t.true(client.logger.calledOnce)
+
+  const data = client.logger.firstCall.args[0]
+
+  t.is(typeof data.duration, 'number')
+  t.true(data.duration > 0)
+  t.deepEqual(data, {
+    method: 'test',
+    params: [{ key: 'value' }],
+    duration: data.duration,
+    result: null,
+    error: new Error('Oops'),
+    addr: client.address
+  })
+})


### PR DESCRIPTION
Fixes #15.

This PR adds middleware support similar to the one in Koa (it uses Koa's middleware composition module). Now even the server call and logging are built-in middleware.

This is how you would add a custom middleware to, for example, measure the time of a call:

```js
const client = new Client()
client.use(async (context, next) => {
  // `context` contains props like `method`, `params`, `options` and `result`

  const startTime = new Date()
  await next();
  const duration = new Date() - startTime
})

await client.call('echo', 'Hello World')
```

Todo:

- [x] Tests ~(blocked by #17)~