### PR TITLE
Add support for setting userAgent

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,9 +36,8 @@ class Client {
       timeout: options.timeout || this.timeout,
       body
     }
-    const userAgent = options.userAgent || this.userAgent
-    if (userAgent) {
-      requestOptions.headers = { 'user-agent': userAgent }
+    if (this.userAgent) {
+      requestOptions.headers = { 'user-agent': this.userAgent }
     }
 
     request.post(this.url, requestOptions, (err, res, body) => {

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ class Client {
 
     this.timeout = options.timeout || 10000
     this.logger = options.logger || noop
+    this.userAgent = options.userAgent || null
   }
 
   makeHTTPRequest (body, options, fn) {
@@ -34,6 +35,10 @@ class Client {
       json: true,
       timeout: options.timeout || this.timeout,
       body
+    }
+    const userAgent = options.userAgent || this.userAgent
+    if (userAgent) {
+      requestOptions.headers = { 'user-agent': userAgent }
     }
 
     request.post(this.url, requestOptions, (err, res, body) => {

--- a/test/_app.js
+++ b/test/_app.js
@@ -14,11 +14,12 @@ const api = {
     return done => {
       setTimeout(done, params[0].time)
     }
-  }
+  },
+  headers: (_, headers) => headers
 }
 
 app.use(post('/rpc', function * () {
-  const body = this.request.body
+  const { body, headers } = this.request
   const {id, method} = body
 
   const res = {
@@ -27,7 +28,7 @@ app.use(post('/rpc', function * () {
   }
 
   try {
-    res.result = yield api[method](body)
+    res.result = yield api[method](body, headers)
   } catch (e) {
     res.error = {
       message: e.toString(),

--- a/test/http.js
+++ b/test/http.js
@@ -58,6 +58,12 @@ test('send params without wrapping in an array', async t => {
   t.true(res.params)
 })
 
+test('send userAgent in request header', async t => {
+  const client = new Client(address, { userAgent: 'test/1.0' })
+  const res = await client.call('headers', true)
+  t.is(res['user-agent'], 'test/1.0')
+})
+
 test('throw when request fails', async t => {
   const client = new Client(address)
   await t.throws(client.call('error', []))


### PR DESCRIPTION
Adds support for setting the `user-agent` http header used to identify the caller.
It is set by adding a `userAgent` field to the options either in the constructor or per-call.

It only really makes sense for http requests, so it is ignored for tcp calls.