### PR TITLE
http request: support adding headers to the request from middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,8 +43,10 @@ class Client {
       timeout: options.timeout || this.timeout,
       body
     }
+
+    requestOptions.headers = options.headers || {}
     if (this.userAgent) {
-      requestOptions.headers = { 'user-agent': this.userAgent }
+      Object.assign(requestOptions.headers, { 'user-agent': this.userAgent })
     }
 
     request.post(this.url, requestOptions, (err, res, body) => {


### PR DESCRIPTION
This is necessary to support tracing using middlewares.  This behavior
was claimed to have been implemented in #18 (to some degree, it's
unclear).

In any case, we set headers in middleware which need to be set on the
outgoing http request.