### PR TITLE
Added handling for non-standard RPC errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,16 +58,16 @@ class Client {
       }
 
       if (body.error) {
-        let err = new Error(body.error);
+        let err = new Error(body.error)
 
-        if (typeof body.error === "object") {
-          err = new Error(body.error.message);
-          err.code = body.error.code;
-          err.data = body.error.data;
+        if (typeof body.error === 'object') {
+          err = new Error(body.error.message)
+          err.code = body.error.code
+          err.data = body.error.data
         }
 
-        debug("error %s: %s", options.id, err.message);
-        return fn(err);
+        debug('error %s: %s', options.id, err.message)
+        return fn(err)
       }
 
       debug('success %s: %j', options.id, body.result || {})

--- a/index.js
+++ b/index.js
@@ -57,13 +57,17 @@ class Client {
         return fn(err)
       }
 
-      if (body.error && typeof body.error === 'object') {
-        const err = new Error(body.error.message)
-        err.code = body.error.code
-        err.data = body.error.data
+      if (body.error) {
+        let err = new Error(body.error);
 
-        debug('error %s: %s', options.id, err.message)
-        return fn(err)
+        if (typeof body.error === "object") {
+          err = new Error(body.error.message);
+          err.code = body.error.code;
+          err.data = body.error.data;
+        }
+
+        debug("error %s: %s", options.id, err.message);
+        return fn(err);
       }
 
       debug('success %s: %j', options.id, body.result || {})


### PR DESCRIPTION
This PR ports [this](https://github.com/segmentio/remote-service-client/blob/master/src/json-rpc-client.js#L100) back here so that we fail on non-standard RPC errors. E.g.:

```
RPC response: {
    "jsonrpc": "2.0",
    "error": "input could not be validated: {ResourceID:rs_1CAWtHWtinN2uDdc1ou8g7NaE1q Rules:0xc00045eb00}: has a primitive type that is NOT VALID -- given: // Expected valid values are:[array boolean integer number null object string]"
}

[2018-10-28 16:20:16.725] [INFO] RPC CALL schema-service.ResourceSchema.SetRules
  duration: 3
  error: null
```